### PR TITLE
fix: use types for API Gateway V2 as we provision such a gateway

### DIFF
--- a/lambda-hello-name/src/index.ts
+++ b/lambda-hello-name/src/index.ts
@@ -1,8 +1,8 @@
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from "aws-lambda";
 
 export const handler = async (
-    event: APIGatewayProxyEvent
-): Promise<APIGatewayProxyResult> => {
+    event: APIGatewayProxyEventV2
+): Promise<APIGatewayProxyResultV2> => {
     const queries = event.queryStringParameters;
     let name = 'there';
 

--- a/lambda-hello-world/src/index.ts
+++ b/lambda-hello-world/src/index.ts
@@ -1,6 +1,6 @@
-import { APIGatewayProxyResult } from "aws-lambda";
+import { APIGatewayProxyResultV2 } from "aws-lambda";
 
-export const handler = async (): Promise<APIGatewayProxyResult> => {
+export const handler = async (): Promise<APIGatewayProxyResultV2> => {
     return {
         statusCode: 200,
         headers: {


### PR DESCRIPTION
while the currently used attributes (e.g. `event.queryStringParameters`) are the same for both types, others like e.g. `event.path` are different in v2 (`event.rawPath`).