### PR TITLE
updated CDK and provider-aws

### DIFF
--- a/cdktf/package-lock.json
+++ b/cdktf/package-lock.json
@@ -1,13 +1,585 @@
 {
   "name": "cdktf",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "cdktf",
+      "version": "1.0.0",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@cdktf/provider-aws": "^5.0.52",
+        "cdktf": "0.9.4",
+        "constructs": "^10.0.9"
+      },
+      "devDependencies": {
+        "@types/aws-lambda": "^8.10.86",
+        "@types/node": "^16.11.12",
+        "typescript": "^4.5.2"
+      },
+      "engines": {
+        "node": ">=10.12"
+      }
+    },
+    "node_modules/@cdktf/provider-aws": {
+      "version": "5.0.52",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-aws/-/provider-aws-5.0.52.tgz",
+      "integrity": "sha512-FVCL1DNtLiQIm6tcoHepieTZJ5cbGTE2rMqcxNPN2oelXqYTef6ln4iEYg55uRqpSk7STw7kMG8EK8+6zVJlyw==",
+      "engines": {
+        "node": ">= 14.17.0"
+      },
+      "peerDependencies": {
+        "cdktf": "^0.9",
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.86",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.86.tgz",
+      "integrity": "sha512-CH7MtDqW8hAm05alc837XHvqKcrfx/kacc4EyUoyN5PoFK3D0lIfN0GK2WsV6YKU4tUsLTLAVLSyBrcFdHP9Bw==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw==",
+      "dev": true
+    },
+    "node_modules/cdktf": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.9.4.tgz",
+      "integrity": "sha512-CuTCNVV3Goptnq3daPVfs9boODEoIrjy09XAj9nkApcozgidPkNIkDcaJCo/7q3rxnoblsK9u2nj6CDUB8cTIg==",
+      "bundleDependencies": [
+        "archiver",
+        "json-stable-stringify"
+      ],
+      "dependencies": {
+        "archiver": "5.3.0",
+        "json-stable-stringify": "^1.0.1"
+      },
+      "peerDependencies": {
+        "constructs": "^10.0.25"
+      }
+    },
+    "node_modules/cdktf/node_modules/archiver": {
+      "version": "5.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.0",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.0.0",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cdktf/node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cdktf/node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/cdktf/node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/async": {
+      "version": "3.2.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/base64-js": {
+      "version": "1.5.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/bl": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/cdktf/node_modules/buffer": {
+      "version": "5.7.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/cdktf/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cdktf/node_modules/compress-commons": {
+      "version": "4.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cdktf/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/core-util-is": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/crc-32": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.3.1"
+      },
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/cdktf/node_modules/crc32-stream": {
+      "version": "4.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cdktf/node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/exit-on-epipe": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/cdktf/node_modules/fs-constants": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/cdktf/node_modules/glob": {
+      "version": "7.2.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cdktf/node_modules/graceful-fs": {
+      "version": "4.2.9",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/cdktf/node_modules/ieee754": {
+      "version": "1.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/cdktf/node_modules/inflight": {
+      "version": "1.0.6",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/cdktf/node_modules/inherits": {
+      "version": "2.0.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/cdktf/node_modules/isarray": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/json-stable-stringify": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/jsonify": {
+      "version": "0.0.0",
+      "inBundle": true,
+      "license": "Public Domain"
+    },
+    "node_modules/cdktf/node_modules/lazystream": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/cdktf/node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/cdktf/node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/lodash.union": {
+      "version": "4.6.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cdktf/node_modules/normalize-path": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/once": {
+      "version": "1.4.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/cdktf/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/printj": {
+      "version": "1.3.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "printj": "bin/printj.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/cdktf/node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cdktf/node_modules/readdir-glob": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/cdktf/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/cdktf/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cdktf/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/cdktf/node_modules/wrappy": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/cdktf/node_modules/zip-stream": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "compress-commons": "^4.1.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/constructs": {
+      "version": "10.0.94",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.94.tgz",
+      "integrity": "sha512-Ff0MifyD8nDXrte8uUwf5sg7IwG+oJ6uAdbMhoqUh0arVTPE/qRO84dcGBqoojsffIR9kgt9u//N8JD+I9HDKg==",
+      "engines": {
+        "node": ">= 12.7.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
   "dependencies": {
     "@cdktf/provider-aws": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@cdktf/provider-aws/-/provider-aws-3.0.1.tgz",
-      "integrity": "sha512-e5YtdoNkw0KCexLYQI+TZGoQMwp//0xvTgVmM5qi4/4EMDXu0TfXbn15Eckdkdfyj+02TY4RYWTFPUvwFeBTmw=="
+      "version": "5.0.52",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-aws/-/provider-aws-5.0.52.tgz",
+      "integrity": "sha512-FVCL1DNtLiQIm6tcoHepieTZJ5cbGTE2rMqcxNPN2oelXqYTef6ln4iEYg55uRqpSk7STw7kMG8EK8+6zVJlyw==",
+      "requires": {}
     },
     "@types/aws-lambda": {
       "version": "8.10.86",
@@ -22,11 +594,12 @@
       "dev": true
     },
     "cdktf": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.8.1.tgz",
-      "integrity": "sha512-12SZiQvl8r6/Y77dDVlIeYym8ny4Mh3M8WNwWNXV0Gy9S4xJyODKYuKYCleaiJxwtHOkkN7Hn0S3RxAZyx3eRg==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.9.4.tgz",
+      "integrity": "sha512-CuTCNVV3Goptnq3daPVfs9boODEoIrjy09XAj9nkApcozgidPkNIkDcaJCo/7q3rxnoblsK9u2nj6CDUB8cTIg==",
       "requires": {
-        "archiver": "5.3.0"
+        "archiver": "5.3.0",
+        "json-stable-stringify": "^1.0.1"
       },
       "dependencies": {
         "archiver": {
@@ -81,7 +654,7 @@
           }
         },
         "async": {
-          "version": "3.2.2",
+          "version": "3.2.3",
           "bundled": true
         },
         "balanced-match": {
@@ -140,11 +713,11 @@
           "bundled": true
         },
         "crc-32": {
-          "version": "1.2.0",
+          "version": "1.2.1",
           "bundled": true,
           "requires": {
             "exit-on-epipe": "~1.0.1",
-            "printj": "~1.1.0"
+            "printj": "~1.3.1"
           }
         },
         "crc32-stream": {
@@ -187,7 +760,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.8",
+          "version": "4.2.9",
           "bundled": true
         },
         "ieee754": {
@@ -208,6 +781,17 @@
         },
         "isarray": {
           "version": "1.0.0",
+          "bundled": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "jsonify": "~0.0.0"
+          }
+        },
+        "jsonify": {
+          "version": "0.0.0",
           "bundled": true
         },
         "lazystream": {
@@ -260,7 +844,7 @@
           "bundled": true
         },
         "minimatch": {
-          "version": "3.0.4",
+          "version": "3.1.2",
           "bundled": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -282,7 +866,7 @@
           "bundled": true
         },
         "printj": {
-          "version": "1.1.2",
+          "version": "1.3.1",
           "bundled": true
         },
         "process-nextick-args": {
@@ -353,9 +937,9 @@
       }
     },
     "constructs": {
-      "version": "10.0.9",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.9.tgz",
-      "integrity": "sha512-C9la/fcnCKe3XIjKPbWuD49mnOYqSWdiMI6TNJmF0ao3pJw6Hap03Q4nsmCxpWMXuMzM546Kw/WnW7ElB3g4OA=="
+      "version": "10.0.94",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.94.tgz",
+      "integrity": "sha512-Ff0MifyD8nDXrte8uUwf5sg7IwG+oJ6uAdbMhoqUh0arVTPE/qRO84dcGBqoojsffIR9kgt9u//N8JD+I9HDKg=="
     },
     "typescript": {
       "version": "4.5.2",

--- a/cdktf/package.json
+++ b/cdktf/package.json
@@ -19,8 +19,8 @@
     "node": ">=10.12"
   },
   "dependencies": {
-    "@cdktf/provider-aws": "^3.0.1",
-    "cdktf": "0.8.1",
+    "@cdktf/provider-aws": "^5.0.52",
+    "cdktf": "0.9.4",
     "constructs": "^10.0.9"
   },
   "devDependencies": {


### PR DESCRIPTION
While following the tutorial here: https://learn.hashicorp.com/tutorials/terraform/cdktf-assets-stacks-lambda?in=terraform/cdktf, I ran into the following errors when I ran `cdktf list`.

```
.gen/providers/random/id.ts:112:17 - error TS2339: Property 'getStringMapAttribute' does not exist on type 'Id'.
return this.getStringMapAttribute('keepers');
                    ~~~~~~~~~~~~~~~~~~~~~
.gen/providers/random/integer.ts:86:17 - error TS2339: Property 'getStringMapAttribute' does not exist on type 'Integer'.
return this.getStringMapAttribute('keepers');
                    ~~~~~~~~~~~~~~~~~~~~~
.gen/providers/random/password.ts:135:17 - error TS2339: Property 'getStringMapAttribute' does not exist on type 'Password'.
return this.getStringMapAttribute('keepers');
                    ~~~~~~~~~~~~~~~~~~~~~
.gen/providers/random/pet.ts:86:17 - error TS2339: Property 'getStringMapAttribute' does not exist on type 'Pet'.
return this.getStringMapAttribute('keepers');
                    ~~~~~~~~~~~~~~~~~~~~~
.gen/providers/random/shuffle.ts:101:17 - error TS2339: Property 'getStringMapAttribute' does not exist on type 'Shuffle'.
return this.getStringMapAttribute('keepers');
                    ~~~~~~~~~~~~~~~~~~~~~
.gen/providers/random/string-resource.ts:135:17 - error TS2339: Property 'getStringMapAttribute' does not exist on type 'StringResource'.
return this.getStringMapAttribute('keepers');
                    ~~~~~~~~~~~~~~~~~~~~~
.gen/providers/random/uuid.ts:65:17 - error TS2339: Property 'getStringMapAttribute' does not exist on type 'Uuid'.
return this.getStringMapAttribute('keepers');
```

Upgrading both of these dependencies to the latest current versions fixes the errors above.

```
    "@cdktf/provider-aws": "^5.0.52",
    "cdktf": "0.9.4",
```