### PR TITLE
fix: remove dependency on superfluous `path` lib to unblock stack synthesis

### DIFF
--- a/cdktf/package.json
+++ b/cdktf/package.json
@@ -23,8 +23,7 @@
     "@cdktf/provider-aws": "^9.0.0",
     "@cdktf/provider-random": "^2.0.0",
     "cdktf": "^0.12.0",
-    "constructs": "^10.1.58",
-    "path": "^0.12.7"
+    "constructs": "^10.1.58"
   },
   "devDependencies": {
     "@types/jest": "^28.1.6",


### PR DESCRIPTION
For reasons unknown, the `cdktf` project in this repository declares a dependency on [a seven-year-old npm package version of `path`](https://www.npmjs.com/package/path) (which describes itself as an "exact copy" of the NodeJS module). Unfortunately, this package is not typed and no types are available otherwise, causing `cdktf list` to fail during synthesis with a `TSError`. Removing the package dependency in favor of the NodeJS native `path` module resolves the issue. 