### PR TITLE
Fully integrated single stack

### DIFF
--- a/cdktf/cdktf.json
+++ b/cdktf/cdktf.json
@@ -6,5 +6,6 @@
   "context": {
     "excludeStackIdFromLogicalIds": "true",
     "allowSepCharsInLogicalIds": "true"
-  }
+  },
+  "projectId": "6778cca1-1cf7-4e9a-b8cc-fe197b83b9b7"
 }

--- a/cdktf/main.ts
+++ b/cdktf/main.ts
@@ -68,9 +68,9 @@ class MyStack extends TerraformStack {
     })
 
     // Upload Lambda zip file to newly created S3 bucket
-    const lambdaArchive = new aws.S3BucketObject(this, `${config.name}-lambda-archive`, {
+    const lambdaArchive = new aws.S3BucketObject(this, `${config.name}-lambda-archive-${nodeJsFunction.asset.assetHash}`, {
       bucket: bucket.bucket,
-      key: `${config.name}/${config.version}`,
+      key: `${config.name}-lambda-archive-${nodeJsFunction.asset.assetHash}`,
       source: nodeJsFunction.asset.path, // returns a posix path
     });
 

--- a/cdktf/main.ts
+++ b/cdktf/main.ts
@@ -7,6 +7,7 @@ import * as aws from '@cdktf/provider-aws';
 import { NodejsFunction } from './lib/nodejs-lambda'
 
 interface LambdaFunctionConfig {
+  name: string,
   path: string,
   handler: string,
   runtime: string,
@@ -28,59 +29,66 @@ const lambdaRolePolicy = {
   ]
 }
 
-class LambdaStack extends TerraformStack {
-  constructor(scope: Construct, name: string, config: LambdaFunctionConfig) {
+class MyStack extends TerraformStack {
+  constructor(scope: Construct, name: string) {
     super(scope, name);
 
     new aws.AwsProvider(this, "provider", {
       region: "us-west-2",
     });
 
-    const helloWorld = new NodejsFunction(this, 'hello-world', {
-      handler: 'index.foo',
-      path: path.join(__dirname, '..', 'lambda-hello-world')
-    })
-
-    const helloName = new NodejsFunction(this, 'hello-name', {
-      handler: 'index.foo',
-      path: path.join(__dirname, '..', 'lambda-hello-name')
-    })
-
     // Create unique S3 bucket that hosts Lambda executable
     const bucket = new aws.S3Bucket(this, "bucket", {
       bucketPrefix: `learn-cdktf-${name}`,
     });
 
-    // Upload Lambda zip file to newly created S3 bucket
-    const lambdaArchive = new aws.S3BucketObject(this, "lambda-archive", {
-      bucket: bucket.bucket,
-      key: `${config.version}/${helloWorld.asset.fileName}`,
-      source: helloWorld.asset.path, // returns a posix path
-    });
+    this.addLambda(bucket, {
+      name: "lambda-hello-world",
+      path: "../lambda-hello-world/dist",
+      handler: "index.handler",
+      runtime: "nodejs16.x",
+      stageName: "hello-world",
+      version: "v0.0.2"
+    })
+
+    this.addLambda(bucket, {
+      name: 'lambda-hello-name',
+      path: "../lambda-hello-name/dist",
+      handler: "index.handler",
+      runtime: "nodejs16.x",
+      stageName: "hello-name",
+      version: "v0.0.1"
+    })
+  }
+
+  addLambda(bucket: aws.S3Bucket, config: LambdaFunctionConfig) {
+    const nodeJsFunction = new NodejsFunction(this, `${config.name}-nodejs`, {
+      handler: 'index.foo',
+      path: path.join(__dirname, '..', config.name)
+    })
 
     // Upload Lambda zip file to newly created S3 bucket
-    new aws.S3BucketObject(this, "lambda-archive1", {
+    const lambdaArchive = new aws.S3BucketObject(this, `${config.name}-lambda-archive`, {
       bucket: bucket.bucket,
-      key: `${config.version}/${helloName.asset.fileName}`,
-      source: helloName.asset.path, // returns a posix path
+      key: `${config.name}/${config.version}`,
+      source: nodeJsFunction.asset.path, // returns a posix path
     });
-
 
     // Create Lambda role
-    const role = new aws.IamRole(this, "lambda-exec", {
-      name: `learn-cdktf-${name}`,
+    const role = new aws.IamRole(this, `${config.name}-role`, {
+      name: `${config.name}`,
       assumeRolePolicy: JSON.stringify(lambdaRolePolicy)
     })
 
     // Add execution role for lambda to write to CloudWatch logs
-    new aws.IamRolePolicyAttachment(this, "lambda-managed-policy", {
+    new aws.IamRolePolicyAttachment(this, `${config.name}-policy`, {
       policyArn: 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
       role: role.name
     })
 
     // Create Lambda function
-    const lambdaFunc = new aws.LambdaFunction(this, "learn-cdktf-lambda", {
-      functionName: `learn-cdktf-${name}`,
+    const lambdaFunc = new aws.LambdaFunction(this, `${config.name}-lambda`, {
+      functionName: `${config.name}`,
       s3Bucket: bucket.bucket,
       s3Key: lambdaArchive.key,
       handler: config.handler,
@@ -89,42 +97,29 @@ class LambdaStack extends TerraformStack {
     });
 
     // Create and configure API gateway
-    const api = new aws.Apigatewayv2Api(this, "api-gw", {
-      name: name,
+    const api = new aws.Apigatewayv2Api(this, `${config.name}-api-gw`, {
+      name: config.name,
       protocolType: "HTTP",
       target: lambdaFunc.arn
     })
 
-    new aws.LambdaPermission(this, "apigw-lambda", {
+    new aws.LambdaPermission(this, `${config.name}-apigw-permission`, {
       functionName: lambdaFunc.functionName,
       action: "lambda:InvokeFunction",
       principal: "apigateway.amazonaws.com",
+
       sourceArn: `${api.executionArn}/*/*`,
     })
 
-    new TerraformOutput(this, 'url', {
+    new TerraformOutput(this, `${config.name}-url`, {
       value: api.apiEndpoint
     });
-
   }
 }
 
+
 const app = new App();
 
-new LambdaStack(app, 'lambda-hello-world', {
-  path: "../lambda-hello-world/dist",
-  handler: "index.handler",
-  runtime: "nodejs10.x",
-  stageName: "hello-world",
-  version: "v0.0.2"
-});
-
-new LambdaStack(app, 'lambda-hello-name', {
-  path: "../lambda-hello-name/dist",
-  handler: "index.handler",
-  runtime: "nodejs10.x",
-  stageName: "hello-name",
-  version: "v0.0.1"
-});
+new MyStack(app, "test-stack")
 
 app.synth();

--- a/lambda-hello-name/dist/index.js
+++ b/lambda-hello-name/dist/index.js
@@ -23,7 +23,7 @@ var handler = async (event) => {
     headers: {
       "Content-Type": "text/html; charset=utf-8"
     },
-    body: `<p>Hello ${name}!</p>`
+    body: `<p>Hello from update3, ${name}!</p>`
   };
 };
 // Annotate the CommonJS export names for ESM import in node:

--- a/lambda-hello-name/dist/index.js.map
+++ b/lambda-hello-name/dist/index.js.map
@@ -1,7 +1,7 @@
 {
   "version": 3,
   "sources": ["../src/index.ts"],
-  "sourcesContent": ["import { APIGatewayProxyEvent, APIGatewayProxyResult } from \"aws-lambda\";\n\nexport const handler = async (\n    event: APIGatewayProxyEvent\n): Promise<APIGatewayProxyResult> => {\n    const queries = event.queryStringParameters;\n    let name = 'there';\n\n    if (queries !== null && queries !== undefined) {\n        if (queries[\"name\"]) {\n            name = queries[\"name\"];\n        }\n    }\n\n    return {\n        statusCode: 200,\n        headers: {\n            'Content-Type': 'text/html; charset=utf-8',\n        },\n        body: `<p>Hello ${name}!</p>`,\n    }\n}\n"],
-  "mappings": ";;;;;;;;AAAA;AAAA;AAAA;AAAA;AAEO,IAAM,UAAU,OACnB,UACiC;AACjC,QAAM,UAAU,MAAM;AACtB,MAAI,OAAO;AAEX,MAAI,YAAY,QAAQ,YAAY,QAAW;AAC3C,QAAI,QAAQ,SAAS;AACjB,aAAO,QAAQ;AAAA;AAAA;AAIvB,SAAO;AAAA,IACH,YAAY;AAAA,IACZ,SAAS;AAAA,MACL,gBAAgB;AAAA;AAAA,IAEpB,MAAM,YAAY;AAAA;AAAA;",
+  "sourcesContent": ["import { APIGatewayProxyEvent, APIGatewayProxyResult } from \"aws-lambda\";\n\nexport const handler = async (\n    event: APIGatewayProxyEvent\n): Promise<APIGatewayProxyResult> => {\n    const queries = event.queryStringParameters;\n    let name = 'there';\n\n    if (queries !== null && queries !== undefined) {\n        if (queries[\"name\"]) {\n            name = queries[\"name\"];\n        }\n    }\n\n    return {\n        statusCode: 200,\n        headers: {\n            'Content-Type': 'text/html; charset=utf-8',\n        },\n        body: `<p>Hello from update3, ${name}!</p>`,\n    }\n}\n"],
+  "mappings": ";;;;;;;;AAAA;AAAA;AAAA;AAAA;AAEO,IAAM,UAAU,OACnB,UACiC;AACjC,QAAM,UAAU,MAAM;AACtB,MAAI,OAAO;AAEX,MAAI,YAAY,QAAQ,YAAY,QAAW;AAC3C,QAAI,QAAQ,SAAS;AACjB,aAAO,QAAQ;AAAA;AAAA;AAIvB,SAAO;AAAA,IACH,YAAY;AAAA,IACZ,SAAS;AAAA,MACL,gBAAgB;AAAA;AAAA,IAEpB,MAAM,0BAA0B;AAAA;AAAA;",
   "names": []
 }

--- a/lambda-hello-name/src/index.ts
+++ b/lambda-hello-name/src/index.ts
@@ -17,6 +17,6 @@ export const handler = async (
         headers: {
             'Content-Type': 'text/html; charset=utf-8',
         },
-        body: `<p>Hello ${name}!</p>`,
+        body: `<p>Hello from update3, ${name}!</p>`,
     }
 }


### PR DESCRIPTION
There were some issues with this stack, namely nodejs10.x is not supported by AWS anymore.

Also, it looked to me that lambda functions were declared 2x. In separate stacks and extra 2x inside the stack code.

### Main purpose
The main purpose of this pull request is to use a single stack. When I'm developing, I don't want to bother with pushing different stacks for my lambda functions. This repo uses single stack. This means that if you make changes to any of the Lambda's, you can quickly deploy without thinking about which stack to use.

`cdktf deploy test-stack` will build the lambda functions and replace code in S3 + update the lambda with this new code. I add the source code archive hash to the S3 bucket object name. This way stack knows when to update.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203987334975139